### PR TITLE
fix migration cannot be reverted

### DIFF
--- a/migrations/m151024_072453_create_route_table.php
+++ b/migrations/m151024_072453_create_route_table.php
@@ -24,10 +24,7 @@ class m151024_072453_create_route_table extends Migration
 
 	public function down()
 	{
-		echo "m151024_072453_create_route_table cannot be reverted.\n";
-
 		$this->dropTable('{{%route}}');
-		return false;
 	}
 
 	/*


### PR DESCRIPTION
Migration has drop table statement but return false instead, this cause table deleted but error raised in migration/down.